### PR TITLE
"vmc create service" should not accept input "0"

### DIFF
--- a/lib/interact/interactive.rb
+++ b/lib/interact/interactive.rb
@@ -250,7 +250,7 @@ module Interactive
       if matches.size == 1
         [true, matches.first]
       elsif choices and ans =~ /^\s*\d+\s*$/ and \
-              res = choices.to_a[ans.to_i - 1]
+              ans.to_i - 1 >= 0 and res = choices.to_a[ans.to_i - 1]
         [true, res]
       elsif matches.size > 1
         puts "Please disambiguate: #{matches.join " or "}?"


### PR DESCRIPTION
If I input "0" in the prompt, the last arugment ("rabbitmq") will be
selected.

---

$ vmc service create
1: postgresql
2: mysql
3: redis
4: mongodb
5: rabbitmq
What kind?> 0
## Name?> rabbitmq-7958e <-- Is this an expected behavior??
