### PR TITLE
Check for JRuby and don't try and use `stty`

### DIFF
--- a/lib/interact/interactive.rb
+++ b/lib/interact/interactive.rb
@@ -563,23 +563,44 @@ module Interactive
           chr(input.getc)
         end
       rescue LoadError
-        def set_input_state(input)
-          return nil unless input.tty?
+        begin
+          require 'java'
+          java_import 'jline.Terminal'
 
-          before = `stty -g`
+          def set_input_state(input)
+            nil
+          end
 
-          Kernel.system("stty -echo -icanon isig")
+          def restore_input_state(input, before)
+            nil
+          end
 
-          before
+          def get_character(input)
+            chr(Terminal.getTerminal.readCharacter(java.lang.System.in))
+          end
+        rescue LoadError
+
+          def set_input_state(input)
+            return nil unless input.tty?
+
+            before = `stty -g`
+
+            Kernel.system("stty -echo -icanon isig")
+
+            before
+          end
+
+          def restore_input_state(input, before)
+            Kernel.system("stty #{before}") if before
+          end
+
+          def get_character(input)
+            chr(input.getc)
+          end
         end
 
-        def restore_input_state(input, before)
-          Kernel.system("stty #{before}") if before
-        end
-
-        def get_character(input)
-          chr(input.getc)
-        end
+      else
+        
       end
     end
   end


### PR DESCRIPTION
JRuby doesn't support shelling out to `stty` because the ruby process does
not have the same terminal as the caller (I think). ANyway, JRuby does have a
builtin jline library that can give you all the echoey fancy stuff that you
need here.

Rewinding doesn't work yet, but I don't know how to test it.  I would suggest
simply disabling it but I don't see how because I I can't find source code
for `disable_rewind`, nor does the sample in the README work for me in which
it is called.
