### PR TITLE
Specify license for licensefinder

### DIFF
--- a/interact.gemspec
+++ b/interact.gemspec
@@ -13,7 +13,8 @@ spec = Gem::Specification.new do |s|
 
   s.platform = Gem::Platform::RUBY
   s.extra_rdoc_files = ["README.md", "LICENSE"]
-
+  s.license = "BSD"
+  
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec",   "~> 2.0"
 


### PR DESCRIPTION
Without this, the licensefinder gem can't easily identify what license the gem uses
